### PR TITLE
Add QHERO bot prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# testing
-gpt testing
+# QHERO Telegram Bot
+
+Пример прототипа системы для любителей квестов. Используется Python 3 и библиотека `aiogram` 3.
+
+## Запуск
+1. Создайте виртуальное окружение и установите зависимости:
+   ```bash
+   pip install aiogram pydantic sqlalchemy asyncpg
+   ```
+2. Создайте файл `.env` или переменные окружения `BOT_TOKEN` и `DB_DSN` для указания токена бота и строки подключения к PostgreSQL.
+3. Запустите бота:
+   ```bash
+   python -m qhero_bot.bot
+   ```
+
+Минимальный webapp находится в каталоге `webapp/`. Это простая HTML‑заглушка.

--- a/qhero_bot/bot.py
+++ b/qhero_bot/bot.py
@@ -1,0 +1,15 @@
+import asyncio
+from aiogram import Bot, Dispatcher
+
+from .config import settings
+from .handlers import all_handlers
+
+async def main():
+    bot = Bot(token=settings.bot_token)
+    dp = Dispatcher()
+    for router in all_handlers:
+        dp.include_router(router)
+    await dp.start_polling(bot)
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/qhero_bot/config.py
+++ b/qhero_bot/config.py
@@ -1,0 +1,7 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    bot_token: str
+    db_dsn: str
+
+settings = Settings()

--- a/qhero_bot/db.py
+++ b/qhero_bot/db.py
@@ -1,0 +1,11 @@
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+from .config import settings
+
+engine = create_async_engine(settings.db_dsn, echo=False, future=True)
+AsyncSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+async def get_session() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/qhero_bot/handlers/__init__.py
+++ b/qhero_bot/handlers/__init__.py
@@ -1,0 +1,3 @@
+from . import start, profile, quests
+
+all_handlers = (start.router, profile.router, quests.router)

--- a/qhero_bot/handlers/profile.py
+++ b/qhero_bot/handlers/profile.py
@@ -1,0 +1,19 @@
+from aiogram import Router, types
+
+from ..db import get_session
+from ..models import User
+
+router = Router()
+
+@router.callback_query(lambda c: c.data == 'profile')
+async def profile_callback(call: types.CallbackQuery):
+    async for session in get_session():
+        user = await session.get(User, call.from_user.id)
+        if not user:
+            user = User(id=call.from_user.id, nickname=call.from_user.username)
+            session.add(user)
+            await session.commit()
+        text = f"Профиль {user.nickname}\nXP: {user.xp}\nУровень: {user.level}"
+    await call.message.edit_text(text, reply_markup=None)
+    await call.answer()
+

--- a/qhero_bot/handlers/quests.py
+++ b/qhero_bot/handlers/quests.py
@@ -1,0 +1,17 @@
+from aiogram import Router, types
+from sqlalchemy import select
+
+from ..db import get_session
+from ..models import Quest
+
+router = Router()
+
+@router.callback_query(lambda c: c.data == 'catalog')
+async def catalog_callback(call: types.CallbackQuery):
+    async for session in get_session():
+        result = await session.execute(select(Quest).limit(5))
+        quests = result.scalars().all()
+        text = '\n'.join(q.title for q in quests) or 'Каталог пуст'
+    await call.message.edit_text(text)
+    await call.answer()
+

--- a/qhero_bot/handlers/start.py
+++ b/qhero_bot/handlers/start.py
@@ -1,0 +1,11 @@
+from aiogram import Router, F
+from aiogram.types import Message
+
+from ..keyboards.main_menu import main_menu
+
+router = Router()
+
+@router.message(F.text == '/start')
+async def cmd_start(message: Message):
+    await message.answer('Добро пожаловать в QHERO! Выберите действие:', reply_markup=main_menu)
+

--- a/qhero_bot/keyboards/__init__.py
+++ b/qhero_bot/keyboards/__init__.py
@@ -1,0 +1,1 @@
+from .main_menu import main_menu

--- a/qhero_bot/keyboards/main_menu.py
+++ b/qhero_bot/keyboards/main_menu.py
@@ -1,0 +1,9 @@
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+main_menu = InlineKeyboardMarkup(inline_keyboard=[
+    [InlineKeyboardButton(text='\ud83d\udc64 Мой профиль', callback_data='profile')],
+    [InlineKeyboardButton(text='\ud83d\udcda Каталог квестов', callback_data='catalog')],
+    [InlineKeyboardButton(text='\ud83d\udd0d Рекомендации', callback_data='recommend')],
+    [InlineKeyboardButton(text='\ud83d\udd25 Горящие квесты', callback_data='hot')],
+])
+

--- a/qhero_bot/models.py
+++ b/qhero_bot/models.py
@@ -1,0 +1,65 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Date, Boolean, Table
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    nickname = Column(String, nullable=False)
+    avatar = Column(String)
+    genres = Column(String)
+    xp = Column(Integer, default=0)
+    level = Column(Integer, default=1)
+    rating_profile = Column(Integer, default=0)
+    area = Column(String)
+    achievements = relationship('UserAchievement', back_populates='user')
+
+class Quest(Base):
+    __tablename__ = 'quests'
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    genres = Column(String)
+    rating = Column(Integer, default=0)
+    price = Column(Integer)
+    features = Column(String)
+    area = Column(String)
+    active_qr_code = Column(String)
+
+class Review(Base):
+    __tablename__ = 'reviews'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    quest_id = Column(Integer, ForeignKey('quests.id'))
+    score = Column(Integer)
+    weight = Column(Integer)
+    genre_match = Column(Integer)
+    text = Column(String)
+
+class Achievement(Base):
+    __tablename__ = 'achievements'
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    xp_value = Column(Integer, default=0)
+    icon = Column(String)
+
+class UserAchievement(Base):
+    __tablename__ = 'user_achievements'
+    user_id = Column(Integer, ForeignKey('users.id'), primary_key=True)
+    achievement_id = Column(Integer, ForeignKey('achievements.id'), primary_key=True)
+    date = Column(Date)
+    user = relationship('User', back_populates='achievements')
+
+class Record(Base):
+    __tablename__ = 'records'
+    user_id = Column(Integer, ForeignKey('users.id'), primary_key=True)
+    quest_id = Column(Integer, ForeignKey('quests.id'), primary_key=True)
+    date = Column(Date)
+    qr_verified = Column(Boolean, default=False)
+
+class HotDeal(Base):
+    __tablename__ = 'hot_deals'
+    quest_id = Column(Integer, ForeignKey('quests.id'), primary_key=True)
+    discount_percent = Column(Integer)
+    valid_until = Column(Date)
+

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>QHERO WebApp</title>
+</head>
+<body>
+<h1>QHERO WebApp</h1>
+<p>Это заглушка для будущего React-приложения.</p>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- set up aiogram Telegram bot prototype
- implement simple database models using SQLAlchemy
- add start, profile and catalog handlers
- create minimal webapp placeholder
- document install and run steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845e4d93e348328ae7df42902a8a020